### PR TITLE
install ansible and rsync

### DIFF
--- a/http/freebsd-10.3/installerconfig
+++ b/http/freebsd-10.3/installerconfig
@@ -14,6 +14,7 @@ EOF
 
 ASSUME_ALWAYS_YES=yes pkg install curl
 ASSUME_ALWAYS_YES=yes pkg install sudo
+ASSUME_ALWAYS_YES=yes pkg install python ansible rsync
 
 cat <<EOF > /etc/rc.conf
 ifconfig_em0="DHCP"


### PR DESCRIPTION
ansible is required for 'kitchen test'.

with rsync and kitchen-sync, it is drastically faster to transfer files.

install python before ansible so that the package creates a symlink to
the real python binary.
