### PR TITLE
install ansible 2.2 from EPEL

### DIFF
--- a/centos-7.2-x86_64.json
+++ b/centos-7.2-x86_64.json
@@ -57,6 +57,7 @@
     "type": "shell",
     "scripts": [
       "scripts/centos-7.2/repo.sh",
+      "scripts/centos/ansible.sh",
       "scripts/centos/virtualbox.sh",
       "scripts/centos/vmware.sh",
       "scripts/common/vagrant.sh",

--- a/scripts/centos-7.2/repo.sh
+++ b/scripts/centos-7.2/repo.sh
@@ -3,5 +3,5 @@
 set -e
 set -x
 
-sudo yum -y install https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
+sudo yum -y install https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 sudo sed -i -e 's/^enabled=1/enabled=0/' /etc/yum.repos.d/epel.repo

--- a/scripts/centos/ansible.sh
+++ b/scripts/centos/ansible.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -x
+
+sudo yum -y --enablerepo=epel install ansible
+sudo yum -y install rsync


### PR DESCRIPTION
ansible 2.2 adds some frequently used tests, and, most importantly,
supports `systemd` module, which is required in distributions that have
switched to `systemd`.