### PR TITLE
[bugfix] inject vagrant `bin` path to ENV['PATH']

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,6 +86,17 @@ end
 
 namespace :reallyenglish do
   require 'yaml'
+
+  # workaround "can't find executable vagrant for gem vagrant. vagrant is not
+  # currently included in the bundle, perhaps you meant to add it to your
+  # Gemfile? (Gem::Exception)". in _bundled_ environemnt, bundler cannot find
+  # `vagrant` gem installed outside of the environment.
+  vagrant_path = ""
+  Bundler.with_clean_env do
+    vagrant_path = Pathname.new(`gem which vagrant`).parent.parent + 'bin'
+  end
+  ENV['PATH'] = "#{vagrant_path}:#{ENV['PATH']}"
+
   @yaml = YAML.load_file("box.reallyenglish.yml")
   ENV['VAGRANT_VAGRANTFILE'] = 'Vagrantfile.reallyenglish'
 

--- a/scripts/openbsd/init.sh
+++ b/scripts/openbsd/init.sh
@@ -25,6 +25,8 @@ EOF
 # others
 sudo ftp -o /usr/local/lib/python2.7/site-packages/ansible/modules/extras/packaging/os/openbsd_pkg.py https://raw.githubusercontent.com/ansible/ansible/b134352d8ca33745c4277e8cb85af3ad2dcae2da/lib/ansible/modules/packaging/os/openbsd_pkg.py
 
-sed -e 's/ \/opt ffs rw,nodev,nosuid 1 2/ \/opt ffs rw,nosuid 1 2/' /etc/fstab | sudo tee /etc/fstab
+sudo sed -i'.bak' -e 's/ \/opt ffs rw,nodev,nosuid 1 2/ \/opt ffs rw,nosuid 1 2/' /etc/fstab
+sudo rm /etc/fstab.bak
 
-sed -e 's/\(ttyC[^0].*getty.*\)on /\1off/' /etc/ttys | sudo tee /etc/ttys > /dev/null
+sudo sed -i'.bak' -e 's/\(ttyC[^0].*getty.*\)on /\1off/' /etc/ttys
+sudo rm /etc/ttys.bak


### PR DESCRIPTION
this fixes an issue that Jenkinsfile cannot be executed in slaves.

```
[packer-template] Running shell script
+ bundle exec rake reallyenglish:clean
/usr/local/lib/ruby/gems/2.2/gems/bundler-1.15.0/lib/bundler/rubygems_integration.rb:432:in
`block in replace_bin_path': can't find executable vagrant for gem vagrant.
vagrant is not currently included in the bundle, perhaps you meant to add it to
your Gemfile? (Gem::Exception)
```