### PR TITLE
Update ansible on openbsd

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/archlinux-x86_64.json
+++ b/archlinux-x86_64.json
@@ -1,7 +1,7 @@
 {
   "builders": [{
     "type": "qemu",
-    "iso_url": "{{user `mirror`}}/iso/2017.07.01/archlinux-2017.07.01-x86_64.iso",
+    "iso_url": "{{user `mirror`}}/iso/2017.10.01/archlinux-2017.10.01-x86_64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-archlinux-x86_64-{{build_type}}",
@@ -26,7 +26,7 @@
   }, {
     "type": "virtualbox-iso",
     "guest_os_type": "ArchLinux_64",
-    "iso_url": "{{user `mirror`}}/iso/2017.07.01/archlinux-2017.07.01-x86_64.iso",
+    "iso_url": "{{user `mirror`}}/iso/2017.10.01/archlinux-2017.10.01-x86_64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-archlinux-x86_64-{{build_type}}",
@@ -52,7 +52,7 @@
   }, {
     "type": "vmware-iso",
     "guest_os_type": "other3xlinux-64",
-    "iso_url": "{{user `mirror`}}/iso/2017.07.01/archlinux-2017.07.01-x86_64.iso",
+    "iso_url": "{{user `mirror`}}/iso/2017.10.01/archlinux-2017.10.01-x86_64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-archlinux-x86_64-{{build_type}}",
@@ -96,7 +96,7 @@
     "cpus": "1",
     "disk_size": "40000",
     "headless": "false",
-    "iso_checksum": "dd03d811211c332d29155069d8e4bb2306c70f33",
+    "iso_checksum": "99357d28070706be18f02472f062e02347ab0e68",
     "iso_checksum_type": "sha1",
     "memory": "512",
     "mirror": "http://mirrors.kernel.org/archlinux",

--- a/reallyenglish_spec/packages_spec.rb
+++ b/reallyenglish_spec/packages_spec.rb
@@ -14,6 +14,13 @@ when "freebsd"
     it { should be_installed }
   end
 when "openbsd"
+  # XXX RE_5_9 does not have the latest ansible yet
+  if os[:release].to_f >= 6.0
+    describe command "ansible --version" do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/^ansible\s+2\.3\.2\.0\s+/) }
+    end
+  end
   if os[:release].to_f >= 6.1
     describe file("/etc/installurl") do
       it { should be_file }

--- a/scripts/openbsd/init.sh
+++ b/scripts/openbsd/init.sh
@@ -8,6 +8,11 @@ installpath = ftp.openbsd.org
 EOF
 
 sudo pkg_add ansible rsync--
+# ensure that only `ansible` is installed from our ports tree
+sudo pkg_delete ansible
+ftp -o - https://github.com/reallyenglish/ports/archive/RE_`uname -r | sed -e 's/[.]/_/'`.tar.gz | sudo tar -C /usr -zxf -
+sudo mv /usr/ports-RE_`uname -r | sed -e 's/[.]/_/'` /usr/ports
+( cd /usr/ports/sysutils/ansible && sudo make install clean && sudo rm -rf /usr/ports/* )
 sudo ln -sf /usr/local/bin/python2.7 /usr/local/bin/python
 sudo ln -sf /usr/local/bin/python2.7-2to3 /usr/local/bin/2to3
 sudo ln -sf /usr/local/bin/python2.7-config /usr/local/bin/python-config
@@ -23,6 +28,7 @@ EOF
 # replace buggy openbsd_pkg.py with the latest, and known-to-work, one.
 # fixes https://github.com/reallyenglish/ansible-role-postfix/issues/13 and
 # others
+# XXX remove the workaround below when 5.9 has the latest ansible
 sudo ftp -o /usr/local/lib/python2.7/site-packages/ansible/modules/extras/packaging/os/openbsd_pkg.py https://raw.githubusercontent.com/ansible/ansible/b134352d8ca33745c4277e8cb85af3ad2dcae2da/lib/ansible/modules/packaging/os/openbsd_pkg.py
 
 sudo sed -i'.bak' -e 's/ \/opt ffs rw,nodev,nosuid 1 2/ \/opt ffs rw,nosuid 1 2/' /etc/fstab


### PR DESCRIPTION
this PR updates ansible version to 2.3.2. note that, as `proot` was introduced _after_ OpenBSD 5.9, the version will not get updated soon.

I will propose to deprecate 5.9 in general use.